### PR TITLE
Fix filter error

### DIFF
--- a/pkg/processor/Processor.go
+++ b/pkg/processor/Processor.go
@@ -52,6 +52,7 @@ func Processor(
 			atomicFilterValue, _, err := filters.LastPrice(tb.Trades, true)
 			if err != nil {
 				log.Error("GetLastPrice: ", err)
+				continue
 			}
 
 			// Identify Pair from tradesblock


### PR DESCRIPTION
When diadata api returns an error, we were adding 0 price to aggregation previously. This is fixed by not including the block.