### PR TITLE
add pools env var for dex trades based scrapers.

### DIFF
--- a/cmd/scrapers/go.mod
+++ b/cmd/scrapers/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sirupsen/logrus v1.9.3
 )
+
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/cmd/scrapers/go.mod
+++ b/cmd/scrapers/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/diadata-org/diadata v1.4.568
-	github.com/diadata-org/lumina-library v0.1.15
+	github.com/diadata-org/lumina-library v0.1.17
 	github.com/ethereum/go-ethereum v1.15.7
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sirupsen/logrus v1.9.3

--- a/cmd/scrapers/main.go
+++ b/cmd/scrapers/main.go
@@ -35,7 +35,14 @@ var (
 	// Comma separated list of exchangepairs. Pairs must be capitalized and symbols separated by hyphen.
 	// It is the responsability of each exchange scraper to determine the correct format for the corresponding API calls.
 	// Format should be as follows Binance:ETH-USDT,Binance:BTC-USDT
-	exchangePairsEnv = utils.Getenv("EXCHANGEPAIRS", "Crypto.com:BTC-USDT,Crypto.com:BTC-USD")
+	exchangePairsEnv = utils.Getenv("EXCHANGEPAIRS", "")
+	// Comma separated list of pools on an exchange.
+	// Format should be as follows PancakeswapV3:0xac0fe1c4126e4a9b644adfc1303827e3bb5dddf3:i
+	// where 0<=i<=2 determines the order of the returned swaps.
+	// 0: original pool order
+	// 1: reversed pool order
+	// 2: both directions
+	poolsEnv = utils.Getenv("POOLS", "")
 
 	exchangePairs []models.ExchangePair
 	pools         []models.Pool
@@ -43,6 +50,12 @@ var (
 
 func init() {
 	exchangePairs = models.ExchangePairsFromEnv(exchangePairsEnv, ENV_SEPARATOR, EXCHANGE_PAIR_SEPARATOR, PAIR_TICKER_SEPARATOR, getPath2Config())
+	var err error
+	pools, err = models.PoolsFromEnv(poolsEnv, ENV_SEPARATOR, EXCHANGE_PAIR_SEPARATOR)
+	if err != nil {
+		log.Fatal("Read pools from ENV var: ", err)
+	}
+
 }
 
 // GetImageVersion returns the Docker image version from environment variable

--- a/cmd/scrapers/main.go
+++ b/cmd/scrapers/main.go
@@ -42,7 +42,7 @@ var (
 	// 0: original pool order
 	// 1: reversed pool order
 	// 2: both directions
-	poolsEnv = utils.Getenv("POOLS", "")
+	poolsEnv = utils.Getenv("POOLS", "PancakeswapV3:0xac0fe1c4126e4a9b644adfc1303827e3bb5dddf3:1,PancakeswapV3:0x36696169C63e42cd08ce11f5deeBbCeBae652050:1")
 
 	exchangePairs []models.ExchangePair
 	pools         []models.Pool

--- a/cmd/simulators/go.mod
+++ b/cmd/simulators/go.mod
@@ -6,7 +6,7 @@ replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alp
 
 require (
 	github.com/diadata-org/diadata v1.4.568
-	github.com/diadata-org/lumina-library v0.1.13
+	github.com/diadata-org/lumina-library v0.1.16
 	github.com/ethereum/go-ethereum v1.15.7
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sirupsen/logrus v1.9.3

--- a/cmd/simulators/go.mod
+++ b/cmd/simulators/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sirupsen/logrus v1.9.3
 )
+
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect


### PR DESCRIPTION
Add pools env var for dex based scrapers. This allows for deployment of univ3 type scrapers (for now UniV3 on Ethereum and PancakeswapV3 on Binance Smart Chain).
Furthermore UniV3 simulator is upgraded in order to include the updated slippage check.