### PR TITLE
refactor: split testnet deploy into subgroups

### DIFF
--- a/.github/workflows/pr-deploy-testnet.yml
+++ b/.github/workflows/pr-deploy-testnet.yml
@@ -6,6 +6,15 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      target:
+        description: 'Deploy target'
+        required: true
+        type: choice
+        options:
+          - scrapers-1
+          - scrapers-2
+          - simulators
 
 permissions:
   contents: read
@@ -13,7 +22,11 @@ permissions:
 
 jobs:
   lint:
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'deploy-testnet'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'deploy-testnet-scrapers-1' ||
+      github.event.label.name == 'deploy-testnet-scrapers-2' ||
+      github.event.label.name == 'deploy-testnet-simulators'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,6 +62,18 @@ jobs:
           COMMIT_HASH=$(git rev-parse --short HEAD)
           echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
 
+      - name: Determine deploy target
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "DEPLOY_TARGET=${{ github.event.inputs.target }}" >> $GITHUB_ENV
+          elif [ "${{ github.event.label.name }}" == "deploy-testnet-scrapers-1" ]; then
+            echo "DEPLOY_TARGET=scrapers-1" >> $GITHUB_ENV
+          elif [ "${{ github.event.label.name }}" == "deploy-testnet-scrapers-2" ]; then
+            echo "DEPLOY_TARGET=scrapers-2" >> $GITHUB_ENV
+          elif [ "${{ github.event.label.name }}" == "deploy-testnet-simulators" ]; then
+            echo "DEPLOY_TARGET=simulators" >> $GITHUB_ENV
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -65,20 +90,24 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: commit-hash-${{ env.COMMIT_HASH }}
         run: |
-          docker build -f build/Dockerfile-luminaScraperFeeder -t ${ECR_REGISTRY}/lumina/decentralized-feeder:${IMAGE_TAG} .
-          docker build -f build/Dockerfile-luminaSimulationFeeder -t ${ECR_REGISTRY}/lumina/simulation-feeder:${IMAGE_TAG} .
+          if [[ "${{ env.DEPLOY_TARGET }}" == "scrapers-1" || "${{ env.DEPLOY_TARGET }}" == "scrapers-2" ]]; then
+            docker build -f build/Dockerfile-luminaScraperFeeder -t ${ECR_REGISTRY}/lumina/decentralized-feeder:${IMAGE_TAG} .
+          elif [ "${{ env.DEPLOY_TARGET }}" == "simulators" ]; then
+            docker build -f build/Dockerfile-luminaSimulationFeeder -t ${ECR_REGISTRY}/lumina/simulation-feeder:${IMAGE_TAG} .
+          fi
 
       - name: Push images to AWS ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: commit-hash-${{ env.COMMIT_HASH }}
         run: |
-          docker push ${ECR_REGISTRY}/lumina/decentralized-feeder:${IMAGE_TAG}
-          docker push ${ECR_REGISTRY}/lumina/simulation-feeder:${IMAGE_TAG}
-
-          echo "Pushed images to AWS ECR:"
-          echo "  ${ECR_REGISTRY}/lumina/decentralized-feeder:${IMAGE_TAG}"
-          echo "  ${ECR_REGISTRY}/lumina/simulation-feeder:${IMAGE_TAG}"
+          if [[ "${{ env.DEPLOY_TARGET }}" == "scrapers-1" || "${{ env.DEPLOY_TARGET }}" == "scrapers-2" ]]; then
+            docker push ${ECR_REGISTRY}/lumina/decentralized-feeder:${IMAGE_TAG}
+            echo "Pushed image: ${ECR_REGISTRY}/lumina/decentralized-feeder:${IMAGE_TAG}"
+          elif [ "${{ env.DEPLOY_TARGET }}" == "simulators" ]; then
+            docker push ${ECR_REGISTRY}/lumina/simulation-feeder:${IMAGE_TAG}
+            echo "Pushed image: ${ECR_REGISTRY}/lumina/simulation-feeder:${IMAGE_TAG}"
+          fi
 
       - name: Checkout lumina-infra repository
         env:
@@ -97,36 +126,38 @@ jobs:
           git config user.name "DIA Lumina Bot"
           git config user.email "infrastructure@diadata.org"
 
-          # Update image registry and tag for testnet scraper feeders
-          SCRAPER_FEEDERS="001-scraper-testnet-aws 004-scraper-testnet-aws 007-scraper-testnet-aws 008-scraper-testnet-aws 009-scraper-testnet-aws"
-          for feeder in $SCRAPER_FEEDERS; do
-            VALUES_FILE="helmcharts/decentral-feeders-aws/${feeder}/values.yaml"
-            if [ -f "$VALUES_FILE" ]; then
-              echo "Updating $VALUES_FILE"
-              sed -i "s|image: [^,]*|image: ${ECR_REGISTRY}/lumina/decentralized-feeder|" "$VALUES_FILE"
-              sed -i "s|tag: [^}]*|tag: commit-hash-${{ env.COMMIT_HASH }}|" "$VALUES_FILE"
-            fi
-          done
+          case "${{ env.DEPLOY_TARGET }}" in
+            scrapers-1)
+              FEEDERS="001-scraper-testnet-aws 004-scraper-testnet-aws"
+              IMAGE="${ECR_REGISTRY}/lumina/decentralized-feeder"
+              ;;
+            scrapers-2)
+              FEEDERS="007-scraper-testnet-aws 008-scraper-testnet-aws 009-scraper-testnet-aws"
+              IMAGE="${ECR_REGISTRY}/lumina/decentralized-feeder"
+              ;;
+            simulators)
+              FEEDERS="101-simulation-testnet-aws 102-simulation-testnet-aws 103-simulation-testnet-aws"
+              IMAGE="${ECR_REGISTRY}/lumina/simulation-feeder"
+              ;;
+          esac
 
-          # Update image registry and tag for testnet simulation feeders
-          SIMULATION_FEEDERS="101-simulation-testnet-aws 102-simulation-testnet-aws 103-simulation-testnet-aws"
-          for feeder in $SIMULATION_FEEDERS; do
+          for feeder in $FEEDERS; do
             VALUES_FILE="helmcharts/decentral-feeders-aws/${feeder}/values.yaml"
             if [ -f "$VALUES_FILE" ]; then
               echo "Updating $VALUES_FILE"
-              sed -i "s|image: [^,]*|image: ${ECR_REGISTRY}/lumina/simulation-feeder|" "$VALUES_FILE"
+              sed -i "s|image: [^,]*|image: ${IMAGE}|" "$VALUES_FILE"
               sed -i "s|tag: [^}]*|tag: commit-hash-${{ env.COMMIT_HASH }}|" "$VALUES_FILE"
             fi
           done
 
           echo "Changes to be committed:"
-          git diff helmcharts/decentral-feeders-aws/*/values.yaml
+          git diff helmcharts/decentral-feeders-aws/
 
           if ! git diff --quiet; then
-            git add helmcharts/decentral-feeders-aws/*/values.yaml
-            git commit -m "Deploy decentral-feeders to testnet (commit-hash-${{ env.COMMIT_HASH }})"
+            git add helmcharts/decentral-feeders-aws/
+            git commit -m "Deploy decentral-feeders (${{ env.DEPLOY_TARGET }}) to testnet (commit-hash-${{ env.COMMIT_HASH }})"
             git push https://$LUMINA_INFRA_PAT@github.com/diadata-org/lumina-infra.git HEAD:master
-            echo "Pushed updates to lumina-infra. ArgoCD will sync AWS testnet feeders automatically."
+            echo "Pushed updates to lumina-infra. ArgoCD will sync ${{ env.DEPLOY_TARGET }} testnet feeders automatically."
           else
             echo "No changes to commit"
           fi

--- a/README.md
+++ b/README.md
@@ -201,6 +201,18 @@ To learn about DIA's oracle stacks, you can visit our documentation [here](https
 
 To report bugs or suggest enhancements, you can create a [Github Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue) in the repository.
 
+## CI/CD Workflows
+
+### Pull Request Pipeline
+
+| Trigger | Workflow | Action |
+|---------|----------|--------|
+| PR opened/updated | pr-pipeline | Lint only |
+| Label `deploy-testnet-scrapers-1` | pr-deploy-testnet | Build + deploy feeders 001, 004 |
+| Label `deploy-testnet-scrapers-2` | pr-deploy-testnet | Build + deploy feeders 007, 008, 009 |
+| Label `deploy-testnet-simulators` | pr-deploy-testnet | Build + deploy feeders 101, 102, 103 |
+| Release published | release-pipeline | Push to AWS ECR + Docker Hub |
+
 ## Contribution Guidelines
 
 Coming soon...


### PR DESCRIPTION
## Summary
- Split testnet deploy into subgroups instead of deploying all feeders at once
- Labels:
  - `deploy-testnet-scrapers-1`: feeders 001, 004
  - `deploy-testnet-scrapers-2`: feeders 007, 008, 009
  - `deploy-testnet-simulators`: feeders 101, 102, 103
- Only builds the required Docker image per target
- Added CI/CD documentation to README

## Workflow behavior

| Trigger | Workflow | Action |
|---------|----------|--------|
| PR opened/updated | pr-pipeline | Lint only |
| Label `deploy-testnet-scrapers-1` | pr-deploy-testnet | Build + deploy feeders 001, 004 |
| Label `deploy-testnet-scrapers-2` | pr-deploy-testnet | Build + deploy feeders 007, 008, 009 |
| Label `deploy-testnet-simulators` | pr-deploy-testnet | Build + deploy feeders 101, 102, 103 |
| Release published | release-pipeline | Push to AWS ECR + Docker Hub |

🤖 Generated with [Claude Code](https://claude.com/claude-code)