### PR TITLE
Fix PAT exposure in git clone/push URLs

### DIFF
--- a/.github/workflows/master-pipeline.yml
+++ b/.github/workflows/master-pipeline.yml
@@ -32,10 +32,11 @@ jobs:
 
       # Checkout the lumina-infra repository
       - name: Checkout lumina-infra repository
-        env:
-          LUMINA_INFRA_PAT: ${{ secrets.LUMINA_INFRA_PAT }}
-        run: |
-          git clone -q https://$LUMINA_INFRA_PAT@github.com/diadata-org/lumina-infra lumina-infra
+        uses: actions/checkout@v4
+        with:
+          repository: diadata-org/lumina-infra
+          token: ${{ secrets.LUMINA_INFRA_PAT }}
+          path: lumina-infra
 
       # Configure AWS credentials and push to ECR
       - name: Configure AWS credentials
@@ -73,7 +74,6 @@ jobs:
       # Update AWS mainnet feeder image tags in lumina-infra
       - name: Update AWS mainnet feeder values and push to lumina-infra
         env:
-          LUMINA_INFRA_PAT: ${{ secrets.LUMINA_INFRA_PAT }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           cd lumina-infra
@@ -101,7 +101,7 @@ jobs:
             git add helmcharts/decentral-feeders-aws/002-scraper-mainnet-aws/values.yaml
             git add helmcharts/decentral-feeders-aws/003-scraper-mainnet-aws/values.yaml
             git commit -m "Deploy AWS mainnet feeders (002, 003): commit-hash-${{ env.COMMIT_HASH }}"
-            git push https://$LUMINA_INFRA_PAT@github.com/diadata-org/lumina-infra.git HEAD:master
+            git push origin HEAD:master
             echo "Pushed updates to lumina-infra. ArgoCD will sync AWS mainnet feeders automatically."
           else
             echo "No changes to commit"

--- a/.github/workflows/pr-deploy-testnet.yml
+++ b/.github/workflows/pr-deploy-testnet.yml
@@ -110,15 +110,14 @@ jobs:
           fi
 
       - name: Checkout lumina-infra repository
-        env:
-          LUMINA_INFRA_PAT: ${{ secrets.LUMINA_INFRA_PAT }}
-        run: |
-          rm -rf lumina-infra
-          git clone -q https://$LUMINA_INFRA_PAT@github.com/diadata-org/lumina-infra lumina-infra
+        uses: actions/checkout@v4
+        with:
+          repository: diadata-org/lumina-infra
+          token: ${{ secrets.LUMINA_INFRA_PAT }}
+          path: lumina-infra
 
       - name: Update AWS testnet feeder values and push to lumina-infra
         env:
-          LUMINA_INFRA_PAT: ${{ secrets.LUMINA_INFRA_PAT }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           cd lumina-infra
@@ -156,7 +155,7 @@ jobs:
           if ! git diff --quiet; then
             git add helmcharts/decentral-feeders-aws/
             git commit -m "Deploy decentral-feeders (${{ env.DEPLOY_TARGET }}) to testnet (commit-hash-${{ env.COMMIT_HASH }})"
-            git push https://$LUMINA_INFRA_PAT@github.com/diadata-org/lumina-infra.git HEAD:master
+            git push origin HEAD:master
             echo "Pushed updates to lumina-infra. ArgoCD will sync ${{ env.DEPLOY_TARGET }} testnet feeders automatically."
           else
             echo "No changes to commit"


### PR DESCRIPTION
Use actions/checkout@v4 with token parameter instead of embedding PAT in git clone URLs. Use 'git push origin' instead of inline PAT.

This prevents potential token exposure in error messages and logs.