### PR TITLE
fix(ci): serialize lumina-infra pushes with a shared concurrency group

### DIFF
--- a/.github/workflows/master-pipeline.yml
+++ b/.github/workflows/master-pipeline.yml
@@ -20,6 +20,11 @@ permissions:
 jobs:
   push_image_and_deploy:
     runs-on: ubuntu-latest
+    # Serialize all jobs pushing to lumina-infra (testnet deploy runs and
+    # this pipeline race on the same branch otherwise)
+    concurrency:
+      group: lumina-infra-push
+      queue: max
     steps:
       # Checkout the repository
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/pr-deploy-testnet.yml
+++ b/.github/workflows/pr-deploy-testnet.yml
@@ -54,6 +54,11 @@ jobs:
   build-and-deploy:
     needs: lint
     runs-on: ubuntu-latest
+    # Serialize all jobs pushing to lumina-infra (parallel deploy runs and
+    # the mainnet pipeline race on the same branch otherwise)
+    concurrency:
+      group: lumina-infra-push
+      queue: max
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## Problem

When a PR is labeled with multiple deploy labels at once (e.g. `deploy-testnet-scrapers-1` and `deploy-testnet-scrapers-2`, as on #229), each label fires its own `decentralized-feeder-deploy-testnet` run. Both runs clone lumina-infra, commit an image tag bump, and push to `master`. Whichever pushes second is rejected with a non-fast-forward error and the whole job fails, leaving that feeder group on the old image tag:

```
! [rejected]  HEAD -> master (fetch first)
error: failed to push some refs to 'https://github.com/diadata-org/lumina-infra'
```

Seen in run https://github.com/diadata-org/decentral-feeder/actions/runs/29480221300 (scrapers-1 lost the race against scrapers-2 by 2 seconds).

The mainnet pipeline (`master-pipeline.yml`) pushes to the same repo/branch and can race with the testnet runs the same way.

## Fix

Add a job-level concurrency group shared by both workflows' deploy jobs:

```yaml
concurrency:
  group: lumina-infra-push
  queue: max
```

Concurrency groups are repository-scoped, so this serializes all jobs that push to lumina-infra, across both workflows. Each queued run checks out lumina-infra only after the previous one has pushed, eliminating the race.

`queue: max` (GA since May 2026) queues up to 100 runs FIFO instead of the old default where only one run could be pending and any additional run cancelled the queued one — so applying all three deploy labels at once is safe.

Trade-off: concurrent deploy jobs now run sequentially, adding roughly the job duration (~80s) per queued run.

## Test plan

- YAML syntax validated for both workflows
- After merge: label a PR with both scraper labels simultaneously and verify both runs complete, the second queuing on the concurrency group and pushing cleanly